### PR TITLE
Rename `tag` in Background Fetch-related code to `id`

### DIFF
--- a/src/client/scripts/helpers/offline-cache.js
+++ b/src/client/scripts/helpers/offline-cache.js
@@ -403,7 +403,12 @@ class OfflineCache {
     }
 
     return navigator.serviceWorker.ready.then(registration => {
-      return registration.backgroundFetch.getTags();
+      // FIXME: `getTags()` is deprecated in favour of `getIds()`. Remove this
+      // check around the Chrome 62 stable release, which is late October 2017.
+      if (BackgroundFetchManager.prototype.hasOwnProperty('getTags'))
+        return registration.backgroundFetch.getTags();
+
+      return registration.backgroundFetch.getIds();
     });
   }
 


### PR DESCRIPTION
`tag` was renamed to `id` and `getTags()` was renamed to `getIds()` in the
two following changes to Background Fetch:

https://github.com/WICG/background-fetch/commit/15dd317bbb2e2c7da12ebb11de547e635e59969f
https://github.com/WICG/background-fetch/commit/1e6e452df9024633e2805ace9020fc147ed483ae

This updates the sample PWA to match these new names, which are now
available in Chrome Canary. Functionality is retained in older versions
of Chrome, with FIXMEs to drop those checks for Chrome 62.